### PR TITLE
chore(exntension): add .nohaz to lc2k exntension list

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "lc2k"
       ],
       "extensions": [
-        ".as"
+        ".as",
+        ".nohaz"
       ],
       "configuration": "./language-configuration.json"
     }],


### PR DESCRIPTION
`.nohaz` file extension is used in Lab 8 as a mark of the data-hazard-free version of the lc2k assembly code.

Small fix. Should work.